### PR TITLE
Fix new ansible-lint warning

### DIFF
--- a/molecule/docker_fedora/playbook.yml
+++ b/molecule/docker_fedora/playbook.yml
@@ -15,3 +15,6 @@
       package:
         name: google-chrome-stable
         state: present
+      retries: 2
+      register: install_chrome
+      until: install_chrome is success

--- a/molecule/openstack/playbook.yml
+++ b/molecule/openstack/playbook.yml
@@ -18,3 +18,6 @@
       package:
         name: jenkins
         state: present
+      retries: 2
+      register: install_jenkins
+      until: install_jenkins is success


### PR DESCRIPTION
New Ansible lint warning 405 - remote package installs should have a
retry