### PR TITLE
Remove yum_repositories tag

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,6 +19,5 @@ galaxy_info:
     - repositories
     - yum
     - dnf
-    - yum_repositories
 
 dependencies: []


### PR DESCRIPTION
Underscores are not permitted in Galaxy tags.